### PR TITLE
Fix typo on portuguese email success feedback

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,7 @@
         }
       ],
       "react/prop-types": 0,
-      "react/react-in-jsx-scope": "off"
+      "react/react-in-jsx-scope": "off",
+      "linebreak-style": ["error", "windows"]
     }
 }

--- a/src/languages/pt.json
+++ b/src/languages/pt.json
@@ -16,7 +16,7 @@
     }
   },
   "emailFeedback": {
-    "success": "Eu email foi enviado!",
+    "success": "Seu email foi enviado!",
     "fail": "Algo deu errado :( Mas toma o meu email: contato@kevbeltrao.com.br."
   }
 }


### PR DESCRIPTION
## What I did
  - Fix typo on portuguese email success feedback
  - Add rule on eslint for windows' developers

## How I did
  - Change "Eu" for "Seu"


## How to test
  - Complete the form and send a message to Kevin, if it's successful, the toast will appear on the top of you're screen.

closes #2  
