### PR TITLE
feature(editorconfig): removing eslint rule to ignore linebreak style…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,6 @@
         }
       ],
       "react/prop-types": 0,
-      "react/react-in-jsx-scope": "off",
-      "linebreak-style": ["error", "windows"]
+      "react/react-in-jsx-scope": "off"
     }
 }


### PR DESCRIPTION
… but enforcing it in the .editorconfig

## What I did
Removed the linebreak style rule to ignore it in the .eslintrc.json file.
Added .editorconfig file to enforce linebreak style

## How to test
Try adding code on windows environment and check if eslint complains about linebreak style.

action #issue-number
